### PR TITLE
Meaningful response payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,24 @@ Go `panic` and `recover`.
 This package is designed for use as HTTP middleware. Handlers wrapped with `httpanic.Gracefully` can `panic` whenever non-OK responses are to be sent to the client.
 
 ```go
+
+var errInvalidRequest = errors.New("invalid request")
+
 func panickyHTTPHandler(w http.ResponseWriter, r *http.Request) {
 	if !validRequest(r) {
-        // Request validation has failed, so send a 400 Bad Request to the
-        // client by panicking.
-		panic(httpanic.Because(errors.New("invalid request"), httpanic.WithStatus(http.StatusBadRequest)))
+		// Request validation has failed, so send a JSON-wrapped error payload
+		// to the client with a 400 status.
+		panic(httpanic.Because(
+			errInvalidRequest,
+			httpanic.WithStatus(http.StatusBadRequest),
+			httpanic.WithExplanation("Request failed validation for example purposes.")))
 	}
 	fmt.Fprintln(w, "Looks good!")
 }
 
 func main() {
 	srv := &http.Server{
-		Handler: httpanic.Gracefully(http.HandlerFunc(panickyHTTPHandler)),
+		Handler: httpanic.GracefullyRender(http.HandlerFunc(panickyHTTPHandler), httpanic.AsJSON),
 	}
 	log.Println(srv.ListenAndServe())
 }

--- a/example_test.go
+++ b/example_test.go
@@ -24,7 +24,9 @@ func panickyHTTPHandler(w http.ResponseWriter, r *http.Request) {
 
 func Example() {
 	srv := &http.Server{
-		Handler: httpanic.Gracefully(http.HandlerFunc(panickyHTTPHandler)),
+		// Return any Reasons to panic as JSON to the client, with an
+		// appropriate HTTP status code.
+		Handler: httpanic.GracefullyRender(http.HandlerFunc(panickyHTTPHandler), httpanic.AsJSON),
 	}
 	log.Println(srv.ListenAndServe())
 }

--- a/httpanic.go
+++ b/httpanic.go
@@ -24,11 +24,9 @@ type Reason struct {
 func (r Reason) MarshalJSON() ([]byte, error) {
 	jr := struct {
 		Error       string `json:"error"`
-		Status      int    `json:"status"`
 		Explanation string `json:"explanation,omitempty"`
 	}{
 		Error:       r.Error(),
-		Status:      r.Status,
 		Explanation: r.Explanation,
 	}
 	return json.Marshal(jr)

--- a/httpanic.go
+++ b/httpanic.go
@@ -3,6 +3,7 @@
 package httpanic
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 )
@@ -17,6 +18,20 @@ type Reason struct {
 
 	// Explanation about why we decided to panic.
 	Explanation string
+}
+
+// MarshalJSON implements custom JSON marshaling for Reason.
+func (r Reason) MarshalJSON() ([]byte, error) {
+	jr := struct {
+		Error       string `json:"error"`
+		Status      int    `json:"status"`
+		Explanation string `json:"explanation,omitempty"`
+	}{
+		Error:       r.Error(),
+		Status:      r.Status,
+		Explanation: r.Explanation,
+	}
+	return json.Marshal(jr)
 }
 
 func (r Reason) Unwrap() error {

--- a/httpanic_test.go
+++ b/httpanic_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestReasonMarshalJSON(t *testing.T) {
-	want := `{"error":"this is an error","status":420,"explanation":"Chill, man!"}`
+	want := `{"error":"this is an error","explanation":"Chill, man!"}`
 	reason := Reason{
 		error:       errors.New("this is an error"),
 		Status:      420,

--- a/httpanic_test.go
+++ b/httpanic_test.go
@@ -1,6 +1,7 @@
 package httpanic
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,22 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
+
+func TestReasonMarshalJSON(t *testing.T) {
+	want := `{"error":"this is an error","status":420,"explanation":"Chill, man!"}`
+	reason := Reason{
+		error:       errors.New("this is an error"),
+		Status:      420,
+		Explanation: "Chill, man!",
+	}
+	b, err := json.Marshal(reason)
+	if err != nil {
+		t.Fatalf("Reason.MarshalJSON(): unexpected error: %v", err)
+	}
+	if got := string(b); got != want {
+		t.Errorf("Reason.MarshalJSON():\n got:%v\nwant:%v\n", got, want)
+	}
+}
 
 func TestBecause(t *testing.T) {
 	testErr := errors.New("test error, please ignore")

--- a/httpanic_test.go
+++ b/httpanic_test.go
@@ -89,7 +89,7 @@ func cuzTest(e error, _ ...Detail) Reason {
 	return Reason{error: e}
 }
 
-func TestRecoverFromPanic(t *testing.T) {
+func TestAttemptToRecover(t *testing.T) {
 	cmpOpts := []cmp.Option{
 		cmp.Comparer(func(x, y error) bool {
 			// Compare the errors by value only.
@@ -125,16 +125,16 @@ func TestRecoverFromPanic(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			defer func() {
 				if r := recover(); r != nil && !tc.shouldPanic {
-					t.Errorf("recoverFromPanic(): unexpected panic: %v", r)
+					t.Errorf("attemptToRecover(): unexpected panic: %v", r)
 				}
 			}()
 			func(t *testing.T) {
 				tcRender := func(w http.ResponseWriter, got Reason) {
 					if diff := cmp.Diff(tc.want, got, cmpOpts...); diff != "" {
-						t.Errorf("recoverFromPanic(): render argument mismatch (-want, +got):\n%v", diff)
+						t.Errorf("attemptToRecover(): render argument mismatch (-want, +got):\n%v", diff)
 					}
 				}
-				defer recoverFromPanic(&httptest.ResponseRecorder{}, tcRender, cuzTest)
+				defer attemptToRecover(&httptest.ResponseRecorder{}, tcRender, cuzTest)
 				panic(tc.p)
 			}(t)
 		})


### PR DESCRIPTION
Expose the ability to make the panic responses meaningful.

A `Renderer` can be passed to `GracefullyRender`, which gives the caller the ability to render a contextually meaningful error response payload to the client when an error is handled.