### PR TITLE
Don't panic when recover() returns nil

### DIFF
--- a/httpanic_test.go
+++ b/httpanic_test.go
@@ -119,9 +119,6 @@ func TestAttemptToRecover(t *testing.T) {
 		want        Reason
 		shouldPanic bool
 	}{
-		"nil": {
-			shouldPanic: true,
-		},
 		"arbitrary other non-reason": {
 			p:           struct{ string }{"this would be weird, but might as well test for it"},
 			shouldPanic: true,


### PR DESCRIPTION
Don't `panic()` when `recover()` returns `nil`.

`recover()` returns `nil` under the following circumstances:

1. It is called outside of a deferred function
2. When the goroutine is not panicking
3. When panic() was called with nil as an argument

Since it is impossible to distinguish between these cases, and because none of the provided functions in this package return pointers and an accidental `nil` isn't possible, don't try to handle this case. Also, make sure we aren't `panic()`ing when the value could be `nil`.